### PR TITLE
Correction d'une coquille dans thematicpuzzle-doc-fr.tex

### DIFF
--- a/doc/thematicpuzzle-doc-fr.tex
+++ b/doc/thematicpuzzle-doc-fr.tex
@@ -186,7 +186,7 @@ L'argument obligatoire, entre \MontreCode{\{...\}}, correspond à la liste des d
 
 \subsection{Raccourcis pour certaines décorations}
 
-Des \textit{raccourcis} francisés ont été créés dans le package, pour des saisies simplifiées d décoration :
+Des \textit{raccourcis} francisés ont été créés dans le package, pour des saisies simplifiées des décorations :
 
 \begin{center}
 	\begin{tblr}{hlines,colspec={Q[m,l]Q[m,l]}}


### PR DESCRIPTION
"d decoration" devient "des décorations".