### PR TITLE
Ajout d'un "\" pour séparer TikZ et language

### DIFF
--- a/doc/thematicpuzzle-doc-en.tex
+++ b/doc/thematicpuzzle-doc-en.tex
@@ -177,7 +177,7 @@ The \textsf{keys}, optional and between \MontreCode{[...]}, are:
 
 \medskip
 
-The optional argument, between \MontreCode{<...>}, corresponds to specific options (in \TikZ language) to pass to the created environment.
+The optional argument, between \MontreCode{<...>}, corresponds to specific options (in \TikZ\ language) to pass to the created environment.
 
 \smallskip
 


### PR DESCRIPTION
Remplacement de "\TikZ language" par "\TikZ\ language" pour que l'espace ne soit pas mangé.